### PR TITLE
Update Kubectl Plugin - v0.0.1

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kedify
 spec:
-  version: "0.0.1"
+  version: "v0.0.1"
   homepage: https://github.com/jkremser/kubectl-kedify
   shortDescription: "Simple TUI based shell script for installing and interfacing with Kedify."
   description: |
@@ -16,7 +16,7 @@ spec:
             values:
               - darwin
               - linux
-      uri: https://github.com//archive/refs/tags/0.0.1.zip
+      uri: https://github.com//archive/refs/tags/v0.0.1.zip
       # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
       sha256: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
       # {{addURIAndSha "https://github.com/jkremser/kubectl-kedify/releases/download/{{ .TagName }}/kubectl-kedify{{ .TagName }}.tar.gz" .TagName }}


### PR DESCRIPTION
:package: Updating kubectl plugin :package:

new yaml manifest for release `v0.0.1`
Make sure the version is correctly set in VERSION file.
This needs to be done before creating the tag for release.

This automated PR was created by [this action][1].

[1]: https://github.com//actions/runs/9956601902