### PR TITLE
Update Kubectl Plugin - v0.0.1

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -18,7 +18,7 @@ spec:
               - linux
       uri: https://github.com/jkremser/kubectl-kedify/archive/refs/tags/v0.0.1.zip
       # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
-      sha256: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+      sha256: 63be9001c4f035b069128d91e15be9a3d4caee33f6fddc6aafe23c5440a5f616
       # {{addURIAndSha "https://github.com/jkremser/kubectl-kedify/releases/download/{{ .TagName }}/kubectl-kedify{{ .TagName }}.tar.gz" .TagName }}
       files:
         - from: "kubectl-kedify-*/kubectl-kedify"


### PR DESCRIPTION
:package: Updating kubectl plugin :package:

new yaml manifest for release `v0.0.1`
Make sure the version is correctly set in VERSION file.
This needs to be done before creating the tag for release.

This automated PR was created by [this action][1].

[1]: https://github.com/jkremser/kubectl-kedify/actions/runs/9957658350